### PR TITLE
Convert to static URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,2 @@
-module.exports = Franz => class BlenderChat extends Franz {
-  async validateUrl(url) {
-    try {
-      const resp = await window.fetch(url, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      const status = resp.status.toString();
-
-      return status.startsWith('2') || status.startsWith('3');
-    } catch (err) {
-      console.error(err);
-    }
-
-    return false;
-  }
-};
-
+// default integration (e.g blender.chat)
+module.exports = Franz => Franz;

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "main": "index.js",
   "author": "brybalicious courtesy Stefan Malzner <stefan@adlk.io>",
   "license": "MIT",
+  "repository": "https://github.com/brybalicious/recipe-blenderchat.git",
   "config": {
-    "serviceURL": "https://{teamId}.chat",
+    "serviceURL": "https://blender.chat",
     "hasNotificationSound": true,
-    "hasCustomUrl": true,
-    "hasTeamId": true,
-    "urlInputSuffix": ".chat"
+    "hasCustomUrl": false,
+    "hasTeamId": false,
+    "message": "The hangout place for Blenderheads. blender.chat is an independent chat server created to help the Blender community to communicate in real-time. blender.chat is part of blender.community"
   }
 }


### PR DESCRIPTION
Blender.Chat without custom URL (from Rocket.Chat)

Enables simple addition of Blender.Chat to Franz services